### PR TITLE
feat: scaffold user chat interface

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="/src/styles/theme.css" />
   </head>
   <body>
-    <div id="app" class="min-h-screen bg-gray-50 dark:bg-gray-900"></div>
-    <script type="module" src="/src/app/user/main.user.ts"></script>
+    <div id="root" class="min-h-screen"></div>
+    <script type="module" src="/src/user/main.user.tsx"></script>
   </body>
 </html>

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,0 +1,6 @@
+declare module 'prismjs';
+declare module 'prismjs/components/prism-json';
+declare module 'prismjs/components/prism-markdown';
+declare module 'prismjs/components/prism-typescript';
+declare module 'prismjs/components/prism-bash';
+declare module 'prismjs/themes/prism.min.css';

--- a/src/user/App.tsx
+++ b/src/user/App.tsx
@@ -1,0 +1,37 @@
+import { Suspense } from 'react';
+import { AuthProvider } from './auth/useAuth';
+import { QueryProvider } from './providers/QueryProvider';
+import { ThemeProvider } from './providers/ThemeProvider';
+import { ToastProvider } from './providers/ToastProvider';
+import { ErrorBoundary } from './providers/ErrorBoundary';
+import { UserRoutes } from './routes';
+
+export function UserApp() {
+  return (
+    <QueryProvider>
+      <AuthProvider>
+        <ThemeProvider>
+          <ToastProvider>
+            <ErrorBoundary>
+              <Suspense
+                fallback={
+                  <div className="flex min-h-screen items-center justify-center bg-background">
+                    <div className="flex flex-col items-center gap-2 text-center">
+                      <div
+                        className="h-10 w-10 animate-spin rounded-full border-2 border-primary border-r-transparent"
+                        aria-hidden
+                      />
+                      <p className="text-sm text-muted-foreground">Loading experience…</p>
+                    </div>
+                  </div>
+                }
+              >
+                <UserRoutes />
+              </Suspense>
+            </ErrorBoundary>
+          </ToastProvider>
+        </ThemeProvider>
+      </AuthProvider>
+    </QueryProvider>
+  );
+}

--- a/src/user/api/chat.ts
+++ b/src/user/api/chat.ts
@@ -1,0 +1,26 @@
+import { http } from './http';
+import type { CreateThreadPayload, Message, SendMessagePayload, ThreadSummary } from './types';
+
+export async function listThreads(params?: { query?: string; page?: number; limit?: number }) {
+  const { data } = await http.get<ThreadSummary[]>('/threads', { params });
+  return data;
+}
+
+export async function createThread(payload: CreateThreadPayload) {
+  const { data } = await http.post<{ id: string }>('/threads', payload);
+  return data;
+}
+
+export async function fetchMessages(threadId: string, cursor?: string) {
+  const { data } = await http.get<Message[]>(`/threads/${threadId}/messages`, { params: { cursor } });
+  return data;
+}
+
+export async function sendMessage(threadId: string, payload: SendMessagePayload) {
+  const { data } = await http.post<Message>(`/threads/${threadId}/messages`, payload);
+  return data;
+}
+
+export async function deleteThread(threadId: string) {
+  await http.delete(`/threads/${threadId}`);
+}

--- a/src/user/api/family.ts
+++ b/src/user/api/family.ts
@@ -1,0 +1,27 @@
+import { http } from './http';
+import type { FamilyOverview, FamilyRequest } from './types';
+
+export async function fetchFamily() {
+  const { data } = await http.get<FamilyOverview>('/family');
+  return data;
+}
+
+export async function fetchFamilyChild(childId: string) {
+  const { data } = await http.get(`/family/children/${childId}`);
+  return data as Record<string, unknown>;
+}
+
+export async function updateFamilyChild(childId: string, payload: Record<string, unknown>) {
+  const { data } = await http.patch(`/family/children/${childId}`, payload);
+  return data as Record<string, unknown>;
+}
+
+export async function submitFamilyRequest(childId: string, payload: Record<string, unknown>) {
+  const { data } = await http.post<FamilyRequest>('/family/requests', { childId, ...payload });
+  return data;
+}
+
+export async function updateFamilyRequest(requestId: string, action: 'approve' | 'deny', note?: string) {
+  const { data } = await http.patch<FamilyRequest>(`/family/requests/${requestId}`, { action, note });
+  return data;
+}

--- a/src/user/api/http.ts
+++ b/src/user/api/http.ts
@@ -1,0 +1,13 @@
+import axios from 'axios';
+
+export const http = axios.create({
+  baseURL: '/api',
+  withCredentials: true,
+});
+
+http.interceptors.response.use(
+  response => response,
+  error => {
+    return Promise.reject(error);
+  },
+);

--- a/src/user/api/kids.ts
+++ b/src/user/api/kids.ts
@@ -1,0 +1,12 @@
+import { http } from './http';
+import type { KidsPreset, Message } from './types';
+
+export async function fetchKidsPresets() {
+  const { data } = await http.get<KidsPreset[]>('/kids/presets');
+  return data;
+}
+
+export async function sendKidsPrompt(payload: { presetKey: string; extras?: Record<string, unknown> }) {
+  const { data } = await http.post<Message>('/kids/prompt', payload);
+  return data;
+}

--- a/src/user/api/profile.ts
+++ b/src/user/api/profile.ts
@@ -1,0 +1,12 @@
+import { http } from './http';
+import type { CurrentUser } from './types';
+
+export async function fetchProfile() {
+  const { data } = await http.get<CurrentUser>('/me');
+  return data;
+}
+
+export async function updateProfile(payload: Partial<Pick<CurrentUser, 'username'>>) {
+  const { data } = await http.patch<CurrentUser>('/profile', payload);
+  return data;
+}

--- a/src/user/api/types.ts
+++ b/src/user/api/types.ts
@@ -1,0 +1,97 @@
+export type Role = 'parent' | 'child' | 'user' | string;
+
+export type CurrentUser = {
+  id: string;
+  username: string;
+  roles: Role[];
+  householdId?: string;
+  children?: ChildSummary[];
+};
+
+export type ChildSummary = {
+  id: string;
+  name: string;
+  avatarUrl?: string;
+  safetyLevel?: string;
+};
+
+export type ThreadSummary = {
+  id: string;
+  title: string;
+  updatedAt: string;
+  pinned?: boolean;
+  folder?: string;
+};
+
+export type MessageAuthorRole = 'user' | 'assistant' | 'system';
+
+export type Message = {
+  id: string;
+  threadId: string;
+  author: {
+    id: string;
+    name: string;
+    role: MessageAuthorRole;
+    avatarUrl?: string;
+  };
+  createdAt: string;
+  content: string;
+  citations?: Array<{ id: string; title: string; url: string }>;
+  attachments?: Array<{
+    id: string;
+    fileName: string;
+    url: string;
+    contentType: string;
+  }>;
+  metadata?: Record<string, unknown>;
+  streaming?: boolean;
+};
+
+export type CreateThreadPayload = {
+  title?: string;
+};
+
+export type SendMessagePayload = {
+  text: string;
+  attachments?: string[];
+};
+
+export type FamilyOverview = {
+  householdId: string;
+  parents: Array<{
+    id: string;
+    name: string;
+    avatarUrl?: string;
+  }>;
+  children: ChildSummary[];
+};
+
+export type FamilyRequest = {
+  id: string;
+  childId: string;
+  type: string;
+  status: 'pending' | 'approved' | 'denied';
+  createdAt: string;
+  payload: Record<string, unknown>;
+};
+
+export type KidsPreset = {
+  key: string;
+  label: string;
+  description: string;
+  icon?: string;
+  prompt: string;
+};
+
+export type UsageSummary = {
+  totals: {
+    messagesToday: number;
+    streak: number;
+    minutesToday: number;
+  };
+  byDay: Array<{
+    date: string;
+    messages: number;
+    minutes: number;
+  }>;
+};

--- a/src/user/api/usage.ts
+++ b/src/user/api/usage.ts
@@ -1,0 +1,7 @@
+import { http } from './http';
+import type { UsageSummary } from './types';
+
+export async function fetchUsageSummary(params: { from?: string; to?: string }) {
+  const { data } = await http.get<UsageSummary>('/usage/summary', { params });
+  return data;
+}

--- a/src/user/auth/RequireAuth.tsx
+++ b/src/user/auth/RequireAuth.tsx
@@ -1,0 +1,24 @@
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
+import { useAuth } from './useAuth';
+
+export function RequireAuth() {
+  const { ready, user } = useAuth();
+  const location = useLocation();
+
+  if (!ready) {
+    return (
+      <div className="flex h-full items-center justify-center p-8">
+        <div className="flex flex-col items-center gap-2 text-center">
+          <div className="h-8 w-8 animate-spin rounded-full border-2 border-primary border-r-transparent" aria-hidden />
+          <p className="text-sm text-muted-foreground">Checking your session…</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return <Navigate to="/login" state={{ from: location }} replace />;
+  }
+
+  return <Outlet />;
+}

--- a/src/user/auth/bootstrap.ts
+++ b/src/user/auth/bootstrap.ts
@@ -1,0 +1,10 @@
+export async function bootstrapAuth() {
+  try {
+    const r = await fetch('/api/me', { credentials: 'include' });
+    if (r.ok) return { authenticated: true, me: await r.json() } as const;
+    if (r.status === 401) return { authenticated: false } as const; // silent — show login
+    return { authenticated: false } as const;
+  } catch {
+    return { authenticated: false } as const;
+  }
+}

--- a/src/user/auth/useAuth.tsx
+++ b/src/user/auth/useAuth.tsx
@@ -1,0 +1,42 @@
+import { createContext, PropsWithChildren, useContext, useEffect, useState } from 'react';
+import { bootstrapAuth } from './bootstrap';
+import type { CurrentUser } from '../api/types';
+
+export type AuthState = {
+  ready: boolean;
+  user?: CurrentUser;
+  roles: string[];
+  setUser: (user?: CurrentUser) => void;
+};
+
+const AuthContext = createContext<AuthState | undefined>(undefined);
+
+export function AuthProvider({ children }: PropsWithChildren) {
+  const [ready, setReady] = useState(false);
+  const [user, setUser] = useState<CurrentUser | undefined>(undefined);
+
+  useEffect(() => {
+    bootstrapAuth().then(result => {
+      if (result.authenticated) {
+        setUser(result.me as CurrentUser);
+      } else {
+        setUser(undefined);
+      }
+      setReady(true);
+    });
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ ready, user, roles: user?.roles ?? [], setUser }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error('useAuth must be used within AuthProvider');
+  }
+  return ctx;
+}

--- a/src/user/components/Chat/AttachmentPicker.tsx
+++ b/src/user/components/Chat/AttachmentPicker.tsx
@@ -1,0 +1,28 @@
+import { ChangeEvent } from 'react';
+import { useToast } from '../../providers/ToastProvider';
+
+const ACCEPTED_TYPES = ['image/*', 'application/pdf', 'text/markdown'];
+
+export function AttachmentPicker({ onSelect }: { onSelect: (files: FileList) => void }) {
+  const toast = useToast();
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const files = event.target.files;
+    if (!files?.length) return;
+    onSelect(files);
+    toast.push({ title: `${files.length} attachment${files.length > 1 ? 's' : ''} ready`, type: 'info' });
+  };
+
+  return (
+    <label className="inline-flex items-center gap-2 rounded-md border border-input px-3 py-2 text-sm hover:bg-muted">
+      <input
+        type="file"
+        className="hidden"
+        accept={ACCEPTED_TYPES.join(',')}
+        multiple
+        onChange={handleChange}
+      />
+      Attach
+    </label>
+  );
+}

--- a/src/user/components/Chat/ChatShell.tsx
+++ b/src/user/components/Chat/ChatShell.tsx
@@ -1,0 +1,20 @@
+import { ReactNode } from 'react';
+import { cn } from '../../utils/cn';
+
+export function ChatShell({
+  left,
+  center,
+  right,
+}: {
+  left: ReactNode;
+  center: ReactNode;
+  right: ReactNode;
+}) {
+  return (
+    <div className="flex h-full min-h-[calc(100vh-4rem)] flex-1 flex-col lg:flex-row">
+      <aside className={cn('w-full border-b lg:w-72 lg:border-b-0 lg:border-r')}>{left}</aside>
+      <main className="flex min-h-[60vh] flex-1 flex-col bg-background">{center}</main>
+      <section className="hidden w-full max-w-sm border-l lg:block">{right}</section>
+    </div>
+  );
+}

--- a/src/user/components/Chat/Citations.tsx
+++ b/src/user/components/Chat/Citations.tsx
@@ -1,0 +1,17 @@
+export function Citations({ citations }: { citations: Array<{ id: string; title: string; url: string }> }) {
+  return (
+    <div className="flex flex-wrap gap-2 text-xs">
+      {citations.map(citation => (
+        <a
+          key={citation.id}
+          href={citation.url}
+          target="_blank"
+          rel="noreferrer noopener"
+          className="rounded-full border border-primary/30 px-3 py-1 text-primary hover:bg-primary/10"
+        >
+          {citation.title}
+        </a>
+      ))}
+    </div>
+  );
+}

--- a/src/user/components/Chat/Composer.tsx
+++ b/src/user/components/Chat/Composer.tsx
@@ -1,0 +1,108 @@
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { createThread, sendMessage } from '../../api/chat';
+import { useChatStore } from '../../state/useChatStore';
+import { SuggestionChips } from './SuggestionChips';
+import { AttachmentPicker } from './AttachmentPicker';
+import { useToast } from '../../providers/ToastProvider';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+const composerSchema = z.object({
+  text: z
+    .string()
+    .min(1, 'Please enter a message')
+    .max(4000, 'Messages are limited to 4000 characters'),
+});
+
+type ComposerValues = z.infer<typeof composerSchema>;
+
+const DEFAULT_SUGGESTIONS = ['Summarize this', 'Explain step by step', 'Give me action items'];
+
+export function Composer() {
+  const threadId = useChatStore(state => state.currentThreadId);
+  const setCurrentThread = useChatStore(state => state.setCurrentThread);
+  const setDraftText = useChatStore(state => state.setDraftText);
+  const { register, handleSubmit, reset, formState, setValue, watch } = useForm<ComposerValues>({
+    resolver: zodResolver(composerSchema),
+    defaultValues: { text: '' },
+  });
+  const queryClient = useQueryClient();
+  const toast = useToast();
+  const textValue = watch('text');
+
+  const createThreadMutation = useMutation({
+    mutationFn: () => createThread({}),
+    onSuccess: async result => {
+      setCurrentThread(result.id);
+      await queryClient.invalidateQueries({ queryKey: ['threads'] });
+    },
+  });
+
+  const sendMutation = useMutation({
+    mutationFn: async ({ id, text }: { id: string; text: string }) => sendMessage(id, { text }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['messages'] });
+    },
+  });
+
+  const onSubmit = handleSubmit(async values => {
+    try {
+      let activeThreadId = threadId;
+      if (!activeThreadId) {
+        const newThread = await createThreadMutation.mutateAsync();
+        activeThreadId = newThread.id;
+      }
+      if (!activeThreadId) {
+        throw new Error('No conversation available.');
+      }
+      await sendMutation.mutateAsync({ id: activeThreadId, text: values.text });
+      reset({ text: '' });
+      setDraftText(activeThreadId, '');
+    } catch (error) {
+      toast.push({ title: 'Failed to send message', description: (error as Error).message, type: 'error' });
+    }
+  });
+
+  return (
+    <form
+      className="space-y-3 border-t bg-background p-4"
+      onSubmit={onSubmit}
+    >
+      <textarea
+        {...register('text')}
+        rows={3}
+        className="w-full resize-none rounded-lg border border-input bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary"
+        placeholder="Send a message"
+        onChange={event => {
+          register('text').onChange(event);
+          if (threadId) setDraftText(threadId, event.target.value);
+        }}
+        aria-label="Message composer"
+      />
+      {formState.errors.text ? (
+        <p className="text-xs text-destructive">{formState.errors.text.message}</p>
+      ) : null}
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <AttachmentPicker onSelect={() => {}} />
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => setValue('text', `${textValue}\n/summary `)}
+            className="rounded-md border border-input px-3 py-1 text-sm text-muted-foreground hover:bg-muted"
+          >
+            /Commands
+          </button>
+          <button
+            type="submit"
+            className="rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow hover:bg-primary/90"
+            disabled={formState.isSubmitting || sendMutation.isPending}
+          >
+            Send
+          </button>
+        </div>
+      </div>
+      <SuggestionChips suggestions={DEFAULT_SUGGESTIONS} onSelect={value => setValue('text', `${textValue}\n${value}`)} />
+    </form>
+  );
+}

--- a/src/user/components/Chat/ConversationList.tsx
+++ b/src/user/components/Chat/ConversationList.tsx
@@ -1,0 +1,89 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { createThread, listThreads } from '../../api/chat';
+import { useChatStore } from '../../state/useChatStore';
+import { EmptyState } from '../Shared/EmptyState';
+import { cn } from '../../utils/cn';
+import { useToast } from '../../providers/ToastProvider';
+
+export function ConversationList() {
+  const queryClient = useQueryClient();
+  const toast = useToast();
+  const { data, isLoading } = useQuery({ queryKey: ['threads'], queryFn: () => listThreads() });
+  const currentThreadId = useChatStore(state => state.currentThreadId);
+  const setCurrentThread = useChatStore(state => state.setCurrentThread);
+
+  const createThreadMutation = useMutation({
+    mutationFn: () => createThread({}),
+    onSuccess: async result => {
+      await queryClient.invalidateQueries({ queryKey: ['threads'] });
+      setCurrentThread(result.id);
+    },
+    onError: error => {
+      toast.push({ title: 'Unable to create conversation', description: (error as Error).message, type: 'error' });
+    },
+  });
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full flex-col gap-2 p-4">
+        {Array.from({ length: 6 }).map((_, index) => (
+          <div key={index} className="h-14 animate-pulse rounded-md bg-muted/60" />
+        ))}
+      </div>
+    );
+  }
+
+  if (!data?.length) {
+    return (
+      <div className="flex h-full flex-col">
+        <EmptyState title="No conversations yet" description="Start a new chat to see it here." />
+        <div className="mt-auto border-t p-3">
+          <button
+            type="button"
+            onClick={() => createThreadMutation.mutate()}
+            className="w-full rounded-md border border-dashed border-primary/50 px-3 py-2 text-sm text-primary hover:bg-primary/10"
+          >
+            + New conversation
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <nav aria-label="Conversations" className="flex h-full flex-col overflow-y-auto">
+      <ul className="flex-1 space-y-1 p-2">
+        {data.map(thread => (
+          <li key={thread.id}>
+            <button
+              type="button"
+              onClick={() => setCurrentThread(thread.id)}
+              className={cn(
+                'w-full rounded-md px-3 py-2 text-left text-sm hover:bg-muted focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary',
+                currentThreadId === thread.id && 'bg-muted font-semibold',
+              )}
+            >
+              <div className="flex items-center justify-between">
+                <span className="truncate">{thread.title || 'Untitled conversation'}</span>
+                {thread.pinned ? <span className="ml-2 text-xs text-primary">Pinned</span> : null}
+              </div>
+              <p className="mt-1 line-clamp-1 text-xs text-muted-foreground">
+                Updated {new Date(thread.updatedAt).toLocaleString()}
+              </p>
+            </button>
+          </li>
+        ))}
+      </ul>
+      <div className="border-t p-3">
+        <button
+          type="button"
+          onClick={() => createThreadMutation.mutate()}
+          className="w-full rounded-md border border-dashed border-primary/50 px-3 py-2 text-sm text-primary hover:bg-primary/10"
+          disabled={createThreadMutation.isPending}
+        >
+          + New conversation
+        </button>
+      </div>
+    </nav>
+  );
+}

--- a/src/user/components/Chat/InlineTools.tsx
+++ b/src/user/components/Chat/InlineTools.tsx
@@ -1,0 +1,36 @@
+import type { Message } from '../../api/types';
+import { useToast } from '../../providers/ToastProvider';
+
+export function InlineTools({ message }: { message: Message }) {
+  const toast = useToast();
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+      <button
+        type="button"
+        onClick={() => {
+          navigator.clipboard.writeText(message.content).then(() =>
+            toast.push({ title: 'Copied to clipboard', type: 'success' }),
+          );
+        }}
+        className="rounded-md border border-transparent px-2 py-1 hover:border-border"
+      >
+        Copy
+      </button>
+      <button
+        type="button"
+        onClick={() => toast.push({ title: 'Coming soon', description: 'Edit & resend is in progress.', type: 'info' })}
+        className="rounded-md border border-transparent px-2 py-1 hover:border-border"
+      >
+        Edit
+      </button>
+      <button
+        type="button"
+        onClick={() => toast.push({ title: 'Retry requested', type: 'info' })}
+        className="rounded-md border border-transparent px-2 py-1 hover:border-border"
+      >
+        Retry
+      </button>
+    </div>
+  );
+}

--- a/src/user/components/Chat/MessageBubble.tsx
+++ b/src/user/components/Chat/MessageBubble.tsx
@@ -1,0 +1,28 @@
+import type { Message } from '../../api/types';
+import { Avatar } from '../Shared/Avatar';
+import { Markdown } from '../Shared/Markdown';
+import { InlineTools } from './InlineTools';
+import { Citations } from './Citations';
+import { cn } from '../../utils/cn';
+
+export function MessageBubble({ message }: { message: Message }) {
+  const isUser = message.author.role === 'user';
+
+  return (
+    <div className={cn('flex gap-3', isUser ? 'flex-row-reverse text-right' : 'flex-row text-left')}>
+      <Avatar name={message.author.name} src={message.author.avatarUrl} size="sm" />
+      <div className={cn('max-w-2xl space-y-2', isUser ? 'items-end text-right' : 'items-start text-left')}>
+        <div
+          className={cn(
+            'rounded-2xl border px-4 py-3 text-sm shadow-sm',
+            isUser ? 'bg-primary text-primary-foreground' : 'bg-muted/50 text-foreground',
+          )}
+        >
+          <Markdown content={message.content} />
+        </div>
+        {message.citations?.length ? <Citations citations={message.citations} /> : null}
+        <InlineTools message={message} />
+      </div>
+    </div>
+  );
+}

--- a/src/user/components/Chat/MessageList.tsx
+++ b/src/user/components/Chat/MessageList.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useRef } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { fetchMessages } from '../../api/chat';
+import { useChatStore } from '../../state/useChatStore';
+import { MessageBubble } from './MessageBubble';
+import { EmptyState } from '../Shared/EmptyState';
+import { StreamingCursor } from './StreamingCursor';
+
+export function MessageList() {
+  const threadId = useChatStore(state => state.currentThreadId);
+  const { data, isLoading } = useQuery({
+    queryKey: ['messages', threadId],
+    queryFn: () => (threadId ? fetchMessages(threadId) : Promise.resolve([])),
+    enabled: Boolean(threadId),
+  });
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    containerRef.current?.scrollTo({ top: containerRef.current.scrollHeight, behavior: 'smooth' });
+  }, [data?.length]);
+
+  if (!threadId) {
+    return <EmptyState title="Select a conversation" description="Choose a chat on the left or start a new one." />;
+  }
+
+  return (
+    <div ref={containerRef} className="flex-1 space-y-6 overflow-y-auto p-4" aria-live="polite">
+      {isLoading && <p className="text-sm text-muted-foreground">Loading messages…</p>}
+      {data?.map(message => (
+        <MessageBubble key={message.id} message={message} />
+      ))}
+      <StreamingCursor />
+    </div>
+  );
+}

--- a/src/user/components/Chat/StreamingCursor.tsx
+++ b/src/user/components/Chat/StreamingCursor.tsx
@@ -1,0 +1,5 @@
+export function StreamingCursor() {
+  return (
+    <span className="inline-flex h-4 w-4 animate-pulse rounded-full bg-primary" aria-hidden />
+  );
+}

--- a/src/user/components/Chat/SuggestionChips.tsx
+++ b/src/user/components/Chat/SuggestionChips.tsx
@@ -1,0 +1,17 @@
+export function SuggestionChips({ suggestions, onSelect }: { suggestions: string[]; onSelect: (value: string) => void }) {
+  if (!suggestions.length) return null;
+  return (
+    <div className="flex flex-wrap gap-2">
+      {suggestions.map(suggestion => (
+        <button
+          key={suggestion}
+          type="button"
+          onClick={() => onSelect(suggestion)}
+          className="rounded-full border border-input bg-muted/50 px-3 py-1 text-sm text-muted-foreground hover:bg-muted"
+        >
+          {suggestion}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/user/components/Family/AllowanceMeter.tsx
+++ b/src/user/components/Family/AllowanceMeter.tsx
@@ -1,0 +1,18 @@
+export function AllowanceMeter({ minutes, limit }: { minutes: number; limit: number }) {
+  const ratio = Math.min(minutes / limit, 1);
+  return (
+    <div>
+      <h4 className="text-sm font-semibold text-muted-foreground">Screen time allowance</h4>
+      <div className="mt-2 h-3 w-full rounded-full bg-muted">
+        <div
+          className="h-full rounded-full bg-emerald-500"
+          style={{ width: `${ratio * 100}%` }}
+          aria-hidden
+        />
+      </div>
+      <p className="mt-1 text-xs text-muted-foreground">
+        {minutes} of {limit} minutes used
+      </p>
+    </div>
+  );
+}

--- a/src/user/components/Family/ChildProfileCard.tsx
+++ b/src/user/components/Family/ChildProfileCard.tsx
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+import { SafetyLevelSelect } from './SafetyLevelSelect';
+import { TimeLimitDial } from './TimeLimitDial';
+import { AllowanceMeter } from './AllowanceMeter';
+import type { ChildSummary } from '../../api/types';
+
+export function ChildProfileCard({ child, onSafetyChange }: { child: ChildSummary; onSafetyChange?: (level: string) => void }) {
+  const [safety, setSafety] = useState(child.safetyLevel ?? 'PG');
+
+  return (
+    <section className="rounded-lg border bg-card p-4 shadow-sm">
+      <header className="flex items-center justify-between gap-3">
+        <div>
+          <h3 className="text-base font-semibold">{child.name}</h3>
+          <p className="text-xs text-muted-foreground">Child ID: {child.id}</p>
+        </div>
+        <SafetyLevelSelect
+          value={safety}
+          onChange={value => {
+            setSafety(value);
+            onSafetyChange?.(value);
+          }}
+        />
+      </header>
+      <div className="mt-4 grid gap-4 md:grid-cols-2">
+        <AllowanceMeter minutes={60} limit={120} />
+        <TimeLimitDial value={safety === 'G' ? 45 : 90} />
+      </div>
+    </section>
+  );
+}

--- a/src/user/components/Family/FamilyCard.tsx
+++ b/src/user/components/Family/FamilyCard.tsx
@@ -1,0 +1,42 @@
+import type { FamilyOverview } from '../../api/types';
+import { Avatar } from '../Shared/Avatar';
+
+export function FamilyCard({ family }: { family: FamilyOverview }) {
+  return (
+    <section className="rounded-lg border bg-card p-6 shadow-sm">
+      <header className="mb-4 flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold">Household</h2>
+          <p className="text-sm text-muted-foreground">{family.householdId}</p>
+        </div>
+      </header>
+      <div className="grid gap-4 md:grid-cols-2">
+        <div>
+          <h3 className="text-sm font-semibold text-muted-foreground">Parents</h3>
+          <ul className="mt-2 space-y-2">
+            {family.parents.map(parent => (
+              <li key={parent.id} className="flex items-center gap-3 rounded-md border border-transparent p-2">
+                <Avatar name={parent.name} src={parent.avatarUrl} size="sm" />
+                <span className="text-sm font-medium">{parent.name}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div>
+          <h3 className="text-sm font-semibold text-muted-foreground">Children</h3>
+          <ul className="mt-2 space-y-2">
+            {family.children.map(child => (
+              <li key={child.id} className="flex items-center gap-3 rounded-md border border-transparent p-2">
+                <Avatar name={child.name} src={child.avatarUrl} size="sm" />
+                <div>
+                  <p className="text-sm font-medium">{child.name}</p>
+                  <p className="text-xs text-muted-foreground">Safety: {child.safetyLevel ?? 'Unconfigured'}</p>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/user/components/Family/SafetyLevelSelect.tsx
+++ b/src/user/components/Family/SafetyLevelSelect.tsx
@@ -1,0 +1,20 @@
+const LEVELS = ['G', 'PG', 'PG-13', 'Teen', 'Custom'];
+
+export function SafetyLevelSelect({ value, onChange }: { value: string; onChange: (value: string) => void }) {
+  return (
+    <label className="flex items-center gap-2 text-sm">
+      <span className="text-muted-foreground">Safety</span>
+      <select
+        value={value}
+        onChange={event => onChange(event.target.value)}
+        className="rounded-md border border-input bg-background px-2 py-1"
+      >
+        {LEVELS.map(level => (
+          <option key={level} value={level}>
+            {level}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/src/user/components/Family/ScheduleGrid.tsx
+++ b/src/user/components/Family/ScheduleGrid.tsx
@@ -1,0 +1,26 @@
+const DAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+
+export function ScheduleGrid({ value }: { value: Record<string, string> }) {
+  return (
+    <table className="w-full table-fixed border-collapse text-left text-sm">
+      <thead>
+        <tr>
+          {DAYS.map(day => (
+            <th key={day} className="border-b p-2 text-muted-foreground">
+              {day}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          {DAYS.map(day => (
+            <td key={day} className="border-b p-2">
+              {value[day] ?? 'Free play'}
+            </td>
+          ))}
+        </tr>
+      </tbody>
+    </table>
+  );
+}

--- a/src/user/components/Family/TimeLimitDial.tsx
+++ b/src/user/components/Family/TimeLimitDial.tsx
@@ -1,0 +1,10 @@
+export function TimeLimitDial({ value }: { value: number }) {
+  const normalized = Math.min(Math.max(value, 0), 120);
+  return (
+    <div className="flex flex-col items-center justify-center rounded-lg border p-4 text-center">
+      <span className="text-sm text-muted-foreground">Daily limit</span>
+      <span className="text-3xl font-semibold">{normalized}m</span>
+      <p className="mt-2 text-xs text-muted-foreground">Adjustable per child</p>
+    </div>
+  );
+}

--- a/src/user/components/Kids/KidsPromptGrid.tsx
+++ b/src/user/components/Kids/KidsPromptGrid.tsx
@@ -1,0 +1,17 @@
+import { KidsTileButton } from './KidsTileButton';
+import type { KidsPreset } from '../../api/types';
+
+export function KidsPromptGrid({ presets, onSelect }: { presets: KidsPreset[]; onSelect: (preset: KidsPreset) => void }) {
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {presets.map(preset => (
+        <KidsTileButton
+          key={preset.key}
+          label={preset.label}
+          description={preset.description}
+          onClick={() => onSelect(preset)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/user/components/Kids/KidsTileButton.tsx
+++ b/src/user/components/Kids/KidsTileButton.tsx
@@ -1,0 +1,22 @@
+import { ReactNode } from 'react';
+import { cn } from '../../utils/cn';
+
+export function KidsTileButton({ label, description, icon, onClick }: { label: string; description?: string; icon?: ReactNode; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'flex h-40 flex-col items-start justify-between rounded-3xl border-4 border-primary/60 bg-primary/10 p-6 text-left shadow-lg transition hover:scale-[1.02] hover:bg-primary/20 focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-4 focus-visible:outline-primary',
+      )}
+    >
+      <div className="text-4xl" aria-hidden>
+        {icon ?? '🌟'}
+      </div>
+      <div>
+        <p className="text-2xl font-extrabold text-primary">{label}</p>
+        {description ? <p className="mt-1 text-base text-primary/80">{description}</p> : null}
+      </div>
+    </button>
+  );
+}

--- a/src/user/components/Kids/KidsVoiceToggle.tsx
+++ b/src/user/components/Kids/KidsVoiceToggle.tsx
@@ -1,0 +1,13 @@
+export function KidsVoiceToggle({ enabled, onChange }: { enabled: boolean; onChange: (value: boolean) => void }) {
+  return (
+    <label className="flex cursor-pointer items-center gap-3 rounded-full bg-primary/20 px-4 py-2 text-primary">
+      <input
+        type="checkbox"
+        checked={enabled}
+        onChange={event => onChange(event.target.checked)}
+        className="h-6 w-6 rounded-full border border-primary"
+      />
+      <span className="text-lg font-semibold">Read aloud</span>
+    </label>
+  );
+}

--- a/src/user/components/Kids/ParentalGate.tsx
+++ b/src/user/components/Kids/ParentalGate.tsx
@@ -1,0 +1,45 @@
+import { useMemo, useState } from 'react';
+
+function generatePuzzle() {
+  const a = Math.ceil(Math.random() * 5) + 1;
+  const b = Math.ceil(Math.random() * 5) + 1;
+  return { question: `${a} + ${b} = ?`, answer: a + b };
+}
+
+export function ParentalGate({ onUnlock }: { onUnlock: () => void }) {
+  const puzzle = useMemo(generatePuzzle, []);
+  const [value, setValue] = useState('');
+  const [error, setError] = useState<string | undefined>();
+
+  return (
+    <div className="rounded-3xl border-4 border-primary/40 bg-background p-6 text-center shadow-lg">
+      <h3 className="text-xl font-bold text-primary">Parent check</h3>
+      <p className="mt-2 text-sm text-muted-foreground">Answer the puzzle to continue.</p>
+      <p className="mt-4 text-2xl font-semibold">{puzzle.question}</p>
+      <input
+        type="number"
+        inputMode="numeric"
+        value={value}
+        onChange={event => setValue(event.target.value)}
+        className="mt-4 w-24 rounded-lg border border-input px-3 py-2 text-center text-lg"
+        aria-label="Parent puzzle answer"
+      />
+      {error ? <p className="mt-2 text-sm text-destructive">{error}</p> : null}
+      <div className="mt-4 flex justify-center gap-2">
+        <button
+          type="button"
+          onClick={() => {
+            if (Number(value) === puzzle.answer) {
+              onUnlock();
+            } else {
+              setError('Oops! Try again.');
+            }
+          }}
+          className="rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground"
+        >
+          Unlock
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/user/components/Shared/Avatar.tsx
+++ b/src/user/components/Shared/Avatar.tsx
@@ -1,0 +1,46 @@
+import { cn } from '../../utils/cn';
+
+type AvatarProps = {
+  name: string;
+  src?: string;
+  size?: 'sm' | 'md' | 'lg';
+  className?: string;
+};
+
+const sizeClasses: Record<NonNullable<AvatarProps['size']>, string> = {
+  sm: 'h-8 w-8 text-sm',
+  md: 'h-10 w-10 text-base',
+  lg: 'h-14 w-14 text-lg',
+};
+
+export function Avatar({ name, src, size = 'md', className }: AvatarProps) {
+  if (src) {
+    return (
+      <img
+        src={src}
+        alt={name}
+        className={cn('rounded-full object-cover', sizeClasses[size], className)}
+        referrerPolicy="no-referrer"
+      />
+    );
+  }
+
+  const initials = name
+    .split(' ')
+    .map(part => part.charAt(0).toUpperCase())
+    .join('')
+    .slice(0, 2);
+
+  return (
+    <div
+      className={cn(
+        'flex items-center justify-center rounded-full bg-muted text-muted-foreground',
+        sizeClasses[size],
+        className,
+      )}
+      aria-hidden
+    >
+      {initials}
+    </div>
+  );
+}

--- a/src/user/components/Shared/CodeBlock.tsx
+++ b/src/user/components/Shared/CodeBlock.tsx
@@ -1,0 +1,25 @@
+import { useEffect, useRef } from 'react';
+import Prism from 'prismjs';
+import 'prismjs/components/prism-json';
+import 'prismjs/components/prism-markdown';
+import 'prismjs/components/prism-typescript';
+import 'prismjs/components/prism-bash';
+import 'prismjs/themes/prism.min.css';
+
+export function CodeBlock({ language, value }: { language?: string; value: string }) {
+  const ref = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    if (ref.current) {
+      Prism.highlightElement(ref.current);
+    }
+  }, [value]);
+
+  return (
+    <pre className="overflow-x-auto rounded-md bg-muted p-4 text-sm" tabIndex={0}>
+      <code ref={ref} className={`language-${language ?? 'tsx'}`}>
+        {value}
+      </code>
+    </pre>
+  );
+}

--- a/src/user/components/Shared/ConfirmDialog.tsx
+++ b/src/user/components/Shared/ConfirmDialog.tsx
@@ -1,0 +1,56 @@
+import { ReactNode, useId } from 'react';
+
+type ConfirmDialogProps = {
+  title: string;
+  description?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  onConfirm: () => void;
+  onCancel?: () => void;
+  trigger: ReactNode;
+};
+
+export function ConfirmDialog({ title, description, confirmLabel = 'Confirm', cancelLabel = 'Cancel', onConfirm, onCancel, trigger }: ConfirmDialogProps) {
+  const dialogId = useId();
+
+  return (
+    <div className="inline">
+      <label htmlFor={dialogId} className="inline">
+        {trigger}
+      </label>
+      <input type="checkbox" id={dialogId} className="peer sr-only" />
+      <div className="fixed inset-0 z-40 hidden items-center justify-center bg-black/50 p-4 peer-checked:flex">
+        <div className="w-full max-w-sm rounded-lg bg-background p-6 shadow-xl">
+          <div className="space-y-2">
+            <h3 className="text-lg font-semibold">{title}</h3>
+            {description ? <p className="text-sm text-muted-foreground">{description}</p> : null}
+          </div>
+          <div className="mt-6 flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={() => {
+                onCancel?.();
+                const input = document.getElementById(dialogId) as HTMLInputElement | null;
+                if (input) input.checked = false;
+              }}
+              className="rounded-md border border-input px-3 py-2 text-sm"
+            >
+              {cancelLabel}
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                onConfirm();
+                const input = document.getElementById(dialogId) as HTMLInputElement | null;
+                if (input) input.checked = false;
+              }}
+              className="rounded-md bg-destructive px-3 py-2 text-sm text-destructive-foreground hover:bg-destructive/90"
+            >
+              {confirmLabel}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/user/components/Shared/EmptyState.tsx
+++ b/src/user/components/Shared/EmptyState.tsx
@@ -1,0 +1,19 @@
+import { ReactNode } from 'react';
+
+export function EmptyState({ icon, title, description, action }: {
+  icon?: ReactNode;
+  title: string;
+  description?: string;
+  action?: ReactNode;
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-3 py-12 text-center text-muted-foreground">
+      {icon ? <div className="text-4xl">{icon}</div> : null}
+      <div>
+        <p className="text-lg font-medium text-foreground">{title}</p>
+        {description ? <p className="mt-1 max-w-md text-sm text-muted-foreground">{description}</p> : null}
+      </div>
+      {action}
+    </div>
+  );
+}

--- a/src/user/components/Shared/ErrorView.tsx
+++ b/src/user/components/Shared/ErrorView.tsx
@@ -1,0 +1,11 @@
+import { ReactNode } from 'react';
+
+export function ErrorView({ title, description, action }: { title?: string; description?: string; action?: ReactNode }) {
+  return (
+    <div role="alert" className="flex flex-col items-center gap-3 rounded-lg border border-destructive/40 bg-destructive/10 p-6">
+      <h2 className="text-lg font-semibold text-destructive">{title ?? 'Something went wrong'}</h2>
+      {description ? <p className="text-sm text-muted-foreground">{description}</p> : null}
+      {action}
+    </div>
+  );
+}

--- a/src/user/components/Shared/Markdown.tsx
+++ b/src/user/components/Shared/Markdown.tsx
@@ -1,0 +1,50 @@
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { CodeBlock } from './CodeBlock';
+import { cn } from '../../utils/cn';
+
+export function Markdown({ content, className }: { content: string; className?: string }) {
+  return (
+    <ReactMarkdown
+      className={cn('prose max-w-none dark:prose-invert prose-pre:p-0', className)}
+      remarkPlugins={[remarkGfm]}
+      components={{
+        code({ inline, className: blockClassName, children, ...props }) {
+          const match = /language-(\w+)/.exec(blockClassName ?? '');
+          if (inline) {
+            return (
+              <code className="rounded bg-muted px-1 py-0.5 text-sm" {...props}>
+                {children}
+              </code>
+            );
+          }
+          return <CodeBlock language={match?.[1]} value={String(children).replace(/\n$/, '')} />;
+        },
+        a({ children, href }) {
+          return (
+            <a
+              href={href}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="text-primary underline underline-offset-2"
+            >
+              {children}
+            </a>
+          );
+        },
+        img({ src, alt }) {
+          return (
+            <img
+              src={src ?? ''}
+              alt={alt ?? ''}
+              className="max-h-64 w-full rounded-lg object-contain"
+              loading="lazy"
+            />
+          );
+        },
+      }}
+    >
+      {content}
+    </ReactMarkdown>
+  );
+}

--- a/src/user/components/Shared/ResizePanel.tsx
+++ b/src/user/components/Shared/ResizePanel.tsx
@@ -1,0 +1,58 @@
+import { ReactNode, useRef, useState } from 'react';
+import { cn } from '../../utils/cn';
+
+export function ResizePanel({
+  children,
+  initialSize = 320,
+  minSize = 240,
+  maxSize = 560,
+  orientation = 'horizontal',
+  className,
+}: {
+  children: ReactNode;
+  initialSize?: number;
+  minSize?: number;
+  maxSize?: number;
+  orientation?: 'horizontal' | 'vertical';
+  className?: string;
+}) {
+  const [size, setSize] = useState(initialSize);
+  const dragging = useRef(false);
+
+  return (
+    <div
+      className={cn('relative flex', orientation === 'horizontal' ? 'flex-col' : 'flex-row', className)}
+      style={orientation === 'horizontal' ? { height: size } : { width: size }}
+    >
+      <div className="flex-1 overflow-hidden">{children}</div>
+      <div
+        role="separator"
+        aria-orientation={orientation}
+        tabIndex={0}
+        className={cn(
+          'absolute flex cursor-grab items-center justify-center bg-transparent transition',
+          orientation === 'horizontal'
+            ? 'inset-x-0 bottom-0 h-2'
+            : 'inset-y-0 right-0 w-2',
+        )}
+        onMouseDown={event => {
+          event.preventDefault();
+          dragging.current = true;
+        }}
+        onMouseUp={() => {
+          dragging.current = false;
+        }}
+        onMouseMove={event => {
+          if (!dragging.current) return;
+          if (orientation === 'horizontal') {
+            const next = Math.min(Math.max(minSize, size + event.movementY), maxSize);
+            setSize(next);
+          } else {
+            const next = Math.min(Math.max(minSize, size + event.movementX), maxSize);
+            setSize(next);
+          }
+        }}
+      />
+    </div>
+  );
+}

--- a/src/user/main.user.tsx
+++ b/src/user/main.user.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { UserApp } from './App';
+import '../styles/global.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <UserApp />
+  </React.StrictMode>,
+);

--- a/src/user/pages/Chat/ChatPage.tsx
+++ b/src/user/pages/Chat/ChatPage.tsx
@@ -1,0 +1,21 @@
+import { ConversationList } from '../../components/Chat/ConversationList';
+import { MessageList } from '../../components/Chat/MessageList';
+import { Composer } from '../../components/Chat/Composer';
+import { ChatShell } from '../../components/Chat/ChatShell';
+
+export default function ChatPage() {
+  return (
+    <div className="flex h-full min-h-screen flex-col">
+      <ChatShell
+        left={<ConversationList />}
+        center={
+          <div className="flex flex-1 flex-col">
+            <MessageList />
+            <Composer />
+          </div>
+        }
+        right={<div className="h-full p-4 text-sm text-muted-foreground">Conversation tools coming soon.</div>}
+      />
+    </div>
+  );
+}

--- a/src/user/pages/FamilyHub/FamilyHubPage.tsx
+++ b/src/user/pages/FamilyHub/FamilyHubPage.tsx
@@ -1,0 +1,51 @@
+import { useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { fetchFamily } from '../../api/family';
+import { useFamilyStore } from '../../state/useFamilyStore';
+import { FamilyCard } from '../../components/Family/FamilyCard';
+import { ChildProfileCard } from '../../components/Family/ChildProfileCard';
+import { ScheduleGrid } from '../../components/Family/ScheduleGrid';
+import { EmptyState } from '../../components/Shared/EmptyState';
+
+export default function FamilyHubPage() {
+  const { data, isLoading } = useQuery({ queryKey: ['family'], queryFn: () => fetchFamily() });
+  const setHousehold = useFamilyStore(state => state.setHousehold);
+
+  useEffect(() => {
+    if (data) {
+      setHousehold(data);
+    }
+  }, [data, setHousehold]);
+
+  if (isLoading) {
+    return <p className="p-6 text-sm text-muted-foreground">Loading household…</p>;
+  }
+
+  if (!data) {
+    return <EmptyState title="Family hub not enabled" description="Connect your household to access family controls." />;
+  }
+
+  return (
+    <div className="space-y-6 p-6">
+      <header className="flex flex-col gap-2">
+        <h1 className="text-3xl font-semibold">Family hub</h1>
+        <p className="text-sm text-muted-foreground">
+          Manage kid safety settings, approve requests, and monitor usage in one place.
+        </p>
+      </header>
+      <FamilyCard family={data} />
+      <div className="grid gap-4 lg:grid-cols-2">
+        {data.children.map(child => (
+          <ChildProfileCard key={child.id} child={child} />
+        ))}
+      </div>
+      <section className="rounded-lg border bg-card p-4">
+        <h2 className="text-lg font-semibold">Weekly schedule</h2>
+        <p className="text-sm text-muted-foreground">Configure study time and quiet hours.</p>
+        <div className="mt-4 overflow-x-auto">
+          <ScheduleGrid value={{ Mon: 'Study 5-7 PM', Tue: 'Free play', Wed: 'Homework 4-6 PM' }} />
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/user/pages/Kids/KidsPage.tsx
+++ b/src/user/pages/Kids/KidsPage.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { fetchKidsPresets, sendKidsPrompt } from '../../api/kids';
+import { useKidsStore } from '../../state/useKidsStore';
+import { KidsPromptGrid } from '../../components/Kids/KidsPromptGrid';
+import { KidsVoiceToggle } from '../../components/Kids/KidsVoiceToggle';
+import { ParentalGate } from '../../components/Kids/ParentalGate';
+import { EmptyState } from '../../components/Shared/EmptyState';
+import { Markdown } from '../../components/Shared/Markdown';
+
+const fallbackPresets = [
+  {
+    key: 'story',
+    label: 'Tell me a story',
+    description: 'A cozy bedtime adventure',
+    prompt: 'Tell me a 5-minute bedtime story about a brave cat. Keep it kind and age-appropriate.',
+  },
+  {
+    key: 'homework',
+    label: 'Help with homework',
+    description: 'Explain homework in simple steps',
+    prompt: 'Help me understand my homework in a simple way.',
+  },
+  {
+    key: 'jokes',
+    label: 'Jokes & Riddles',
+    description: 'Silly fun for kids',
+    prompt: 'Tell me three kid-friendly jokes with emojis.',
+  },
+];
+
+export default function KidsPage() {
+  const { data } = useQuery({ queryKey: ['kids-presets'], queryFn: () => fetchKidsPresets(), staleTime: 5 * 60 * 1000 });
+  const { presets, setPresets, voiceEnabled, setVoiceEnabled, markUsed, lastUsed } = useKidsStore();
+  const [latestResponse, setLatestResponse] = useState<string>('');
+  const [parentUnlocked, setParentUnlocked] = useState(false);
+
+  useEffect(() => {
+    if (data?.length) {
+      setPresets(data);
+    } else if (!presets.length) {
+      setPresets(fallbackPresets);
+    }
+  }, [data, presets.length, setPresets]);
+
+  const handleSelect = async (preset: (typeof fallbackPresets)[number]) => {
+    setLatestResponse('');
+    markUsed(preset.key);
+    try {
+      const response = await sendKidsPrompt({ presetKey: preset.key });
+      setLatestResponse(response.content);
+    } catch (error) {
+      setLatestResponse('Unable to contact the kids assistant right now. Please try again later.');
+    }
+  };
+
+  if (!parentUnlocked) {
+    return (
+      <div
+        className="flex min-h-screen items-center justify-center p-6"
+        style={{ background: 'linear-gradient(135deg, #fde68a, #fbcfe8, #bfdbfe)' }}
+      >
+        <ParentalGate onUnlock={() => setParentUnlocked(true)} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen p-6" style={{ background: 'linear-gradient(180deg, #fef3c7, #ffffff, #bfdbfe)' }}>
+      <header className="flex flex-col items-center justify-between gap-4 rounded-3xl bg-white/80 p-6 text-center shadow-xl md:flex-row md:text-left">
+        <div>
+          <h1 className="text-4xl font-black text-primary">Kids chat playground</h1>
+          <p className="mt-2 text-lg text-muted-foreground">Tap a card to start a magical conversation.</p>
+        </div>
+        <KidsVoiceToggle enabled={voiceEnabled} onChange={setVoiceEnabled} />
+      </header>
+      <main className="mx-auto mt-8 max-w-6xl space-y-8">
+        <KidsPromptGrid presets={presets.length ? presets : fallbackPresets} onSelect={handleSelect} />
+        <section className="rounded-3xl bg-white/90 p-6 shadow-lg">
+          <h2 className="text-2xl font-bold text-primary">Assistant replies</h2>
+          {latestResponse ? (
+            <Markdown content={latestResponse} className="mt-4 text-lg" />
+          ) : (
+            <EmptyState title="Pick a tile to begin" description="Responses will appear here with big friendly text." />
+          )}
+          {lastUsed ? (
+            <p className="mt-4 text-sm text-muted-foreground">Last activity: {new Date().toLocaleTimeString()}</p>
+          ) : null}
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/src/user/pages/Login/LoginPage.tsx
+++ b/src/user/pages/Login/LoginPage.tsx
@@ -1,0 +1,81 @@
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import axios from 'axios';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { useAuth } from '../../auth/useAuth';
+import { useToast } from '../../providers/ToastProvider';
+
+const loginSchema = z.object({
+  username: z.string().min(1, 'Username is required'),
+  password: z.string().min(1, 'Password is required'),
+});
+
+type LoginValues = z.infer<typeof loginSchema>;
+
+export default function LoginPage() {
+  const { register, handleSubmit, formState } = useForm<LoginValues>({ resolver: zodResolver(loginSchema) });
+  const toast = useToast();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { setUser } = useAuth();
+
+  const onSubmit = handleSubmit(async values => {
+    try {
+      await axios.post(
+        '/api/auth/login',
+        values,
+        {
+          withCredentials: true,
+        },
+      );
+      const { data } = await axios.get('/api/me', { withCredentials: true });
+      setUser(data);
+      navigate((location.state as any)?.from?.pathname ?? '/chat', { replace: true });
+    } catch (error) {
+      toast.push({ title: 'Invalid credentials', description: 'Please try again.', type: 'error' });
+    }
+  });
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-br from-primary/10 via-background to-background p-6">
+      <div className="w-full max-w-md rounded-3xl border border-primary/30 bg-background/80 p-8 shadow-xl backdrop-blur">
+        <h1 className="text-3xl font-bold text-primary">Welcome to LChaty</h1>
+        <p className="mt-2 text-sm text-muted-foreground">Sign in to access your family hub and chats.</p>
+        <form className="mt-6 space-y-4" onSubmit={onSubmit}>
+          <label className="block text-sm font-medium">
+            <span className="text-muted-foreground">Username</span>
+            <input
+              type="text"
+              autoComplete="username"
+              {...register('username')}
+              className="mt-1 w-full rounded-lg border border-input bg-background px-3 py-2"
+            />
+            {formState.errors.username ? (
+              <span className="mt-1 block text-xs text-destructive">{formState.errors.username.message}</span>
+            ) : null}
+          </label>
+          <label className="block text-sm font-medium">
+            <span className="text-muted-foreground">Password</span>
+            <input
+              type="password"
+              autoComplete="current-password"
+              {...register('password')}
+              className="mt-1 w-full rounded-lg border border-input bg-background px-3 py-2"
+            />
+            {formState.errors.password ? (
+              <span className="mt-1 block text-xs text-destructive">{formState.errors.password.message}</span>
+            ) : null}
+          </label>
+          <button
+            type="submit"
+            className="w-full rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground"
+            disabled={formState.isSubmitting}
+          >
+            Sign in
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/user/pages/Profile/ProfilePage.tsx
+++ b/src/user/pages/Profile/ProfilePage.tsx
@@ -1,0 +1,36 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchProfile } from '../../api/profile';
+import { EmptyState } from '../../components/Shared/EmptyState';
+
+export default function ProfilePage() {
+  const { data, isLoading } = useQuery({ queryKey: ['profile'], queryFn: () => fetchProfile() });
+
+  if (isLoading) {
+    return <p className="p-6 text-sm text-muted-foreground">Loading profile…</p>;
+  }
+
+  if (!data) {
+    return <EmptyState title="No profile" description="We could not load your profile information." />;
+  }
+
+  return (
+    <div className="space-y-6 p-6">
+      <header>
+        <h1 className="text-2xl font-semibold">Profile</h1>
+        <p className="text-sm text-muted-foreground">Manage your personal information.</p>
+      </header>
+      <div className="rounded-lg border bg-card p-6 shadow-sm">
+        <dl className="grid gap-4 md:grid-cols-2">
+          <div>
+            <dt className="text-xs uppercase text-muted-foreground">Username</dt>
+            <dd className="text-lg font-semibold">{data.username}</dd>
+          </div>
+          <div>
+            <dt className="text-xs uppercase text-muted-foreground">Roles</dt>
+            <dd className="text-lg font-semibold">{data.roles.join(', ')}</dd>
+          </div>
+        </dl>
+      </div>
+    </div>
+  );
+}

--- a/src/user/pages/Settings/SettingsPage.tsx
+++ b/src/user/pages/Settings/SettingsPage.tsx
@@ -1,0 +1,47 @@
+import { useUIStore } from '../../state/useUIStore';
+
+export default function SettingsPage() {
+  const theme = useUIStore(state => state.theme);
+  const setTheme = useUIStore(state => state.setTheme);
+  const compactMode = useUIStore(state => state.compactMode);
+  const setCompactMode = useUIStore(state => state.setCompactMode);
+
+  return (
+    <div className="space-y-6 p-6">
+      <header>
+        <h1 className="text-2xl font-semibold">Settings</h1>
+        <p className="text-sm text-muted-foreground">Customize the app experience to match your preferences.</p>
+      </header>
+      <section className="space-y-4 rounded-lg border bg-card p-6 shadow-sm">
+        <div>
+          <h2 className="text-lg font-semibold">Appearance</h2>
+          <p className="text-sm text-muted-foreground">Choose a theme to match your environment.</p>
+          <div className="mt-3 flex gap-2">
+            {['light', 'dark', 'system'].map(option => (
+              <button
+                key={option}
+                type="button"
+                onClick={() => setTheme(option as typeof theme)}
+                className={`rounded-md border px-3 py-2 text-sm ${theme === option ? 'border-primary bg-primary/10 text-primary' : 'border-input'}`}
+              >
+                {option}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div>
+          <h2 className="text-lg font-semibold">Layout</h2>
+          <label className="mt-2 flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={compactMode}
+              onChange={event => setCompactMode(event.target.checked)}
+              className="h-4 w-4"
+            />
+            <span>Compact messages</span>
+          </label>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/user/pages/Threads/ThreadsPage.tsx
+++ b/src/user/pages/Threads/ThreadsPage.tsx
@@ -1,0 +1,38 @@
+import { useQuery } from '@tanstack/react-query';
+import { listThreads } from '../../api/chat';
+import type { ThreadSummary } from '../../api/types';
+import { EmptyState } from '../../components/Shared/EmptyState';
+
+export default function ThreadsPage() {
+  const { data, isLoading } = useQuery({ queryKey: ['threads'], queryFn: () => listThreads() });
+
+  if (isLoading) {
+    return <p className="p-6 text-sm text-muted-foreground">Loading threads…</p>;
+  }
+
+  if (!data?.length) {
+    return <EmptyState title="No threads" description="You have not created any conversations yet." />;
+  }
+
+  return (
+    <div className="space-y-4 p-6">
+      <header>
+        <h1 className="text-2xl font-semibold">All conversations</h1>
+        <p className="text-sm text-muted-foreground">Search and manage every thread in your workspace.</p>
+      </header>
+      <ul className="space-y-3">
+        {data.map((thread: ThreadSummary) => (
+          <li key={thread.id} className="rounded-lg border bg-card p-4 shadow-sm">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-base font-semibold">{thread.title || 'Untitled conversation'}</p>
+                <p className="text-xs text-muted-foreground">Updated {new Date(thread.updatedAt).toLocaleString()}</p>
+              </div>
+              {thread.pinned ? <span className="rounded-full bg-primary/10 px-3 py-1 text-xs text-primary">Pinned</span> : null}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/user/pages/Usage/UsagePage.tsx
+++ b/src/user/pages/Usage/UsagePage.tsx
@@ -1,0 +1,64 @@
+import { useQuery } from '@tanstack/react-query';
+import { Area, AreaChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import { fetchUsageSummary } from '../../api/usage';
+import { EmptyState } from '../../components/Shared/EmptyState';
+
+export default function UsagePage() {
+  const { data, isLoading, isError } = useQuery({ queryKey: ['usage-summary'], queryFn: () => fetchUsageSummary({}) });
+
+  if (isLoading) {
+    return <p className="p-6 text-sm text-muted-foreground">Loading usage analytics…</p>;
+  }
+
+  if (isError || !data) {
+    return (
+      <EmptyState
+        title="Usage analytics unavailable"
+        description="We could not load your usage summary. Please try again later."
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-6 p-6">
+      <header>
+        <h1 className="text-2xl font-semibold">Usage insights</h1>
+        <p className="text-sm text-muted-foreground">Track engagement trends across your household.</p>
+      </header>
+      <section className="grid gap-4 sm:grid-cols-3">
+        <div className="rounded-lg border bg-card p-4 shadow-sm">
+          <p className="text-xs uppercase text-muted-foreground">Messages today</p>
+          <p className="text-3xl font-semibold">{data.totals.messagesToday}</p>
+        </div>
+        <div className="rounded-lg border bg-card p-4 shadow-sm">
+          <p className="text-xs uppercase text-muted-foreground">Streak</p>
+          <p className="text-3xl font-semibold">{data.totals.streak} days</p>
+        </div>
+        <div className="rounded-lg border bg-card p-4 shadow-sm">
+          <p className="text-xs uppercase text-muted-foreground">Time today</p>
+          <p className="text-3xl font-semibold">{data.totals.minutesToday} min</p>
+        </div>
+      </section>
+      <section className="rounded-lg border bg-card p-6 shadow-sm">
+        <h2 className="text-lg font-semibold">Messages by day</h2>
+        <div className="mt-4 h-64 w-full">
+          <ResponsiveContainer width="100%" height="100%">
+            <AreaChart data={data.byDay}>
+              <defs>
+                <linearGradient id="colorMessages" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor="hsl(var(--primary))" stopOpacity={0.8} />
+                  <stop offset="95%" stopColor="hsl(var(--primary))" stopOpacity={0} />
+                </linearGradient>
+              </defs>
+              <CartesianGrid strokeDasharray="3 3" opacity={0.2} />
+              <XAxis dataKey="date" fontSize={12} />
+              <YAxis fontSize={12} allowDecimals={false} />
+              <Tooltip cursor={{ strokeDasharray: '3 3' }} />
+              <Area type="monotone" dataKey="messages" stroke="hsl(var(--primary))" fillOpacity={1} fill="url(#colorMessages)" />
+            </AreaChart>
+          </ResponsiveContainer>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/user/providers/ErrorBoundary.tsx
+++ b/src/user/providers/ErrorBoundary.tsx
@@ -1,0 +1,57 @@
+import { Component, ErrorInfo, ReactNode } from 'react';
+import { useToast } from './ToastProvider';
+
+type ErrorBoundaryProps = {
+  children: ReactNode;
+  fallback?: ReactNode;
+  onError?: (error: Error, info: ErrorInfo) => void;
+};
+
+type ErrorBoundaryState = {
+  hasError: boolean;
+};
+
+class ErrorBoundaryInner extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError() {
+    return { hasError: true } satisfies ErrorBoundaryState;
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    this.props.onError?.(error, info);
+    console.error('ErrorBoundary', error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback ?? (
+        <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-6 text-center">
+          <h1 className="text-2xl font-semibold">Something went wrong</h1>
+          <p className="max-w-md text-muted-foreground">
+            We encountered an unexpected error. Please refresh the page or contact support if the problem persists.
+          </p>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+export function ErrorBoundary({ children, fallback }: Omit<ErrorBoundaryProps, 'onError'>) {
+  const toast = useToast();
+  return (
+    <ErrorBoundaryInner
+      fallback={fallback}
+      onError={error =>
+        toast.push({
+          title: 'Unexpected error',
+          description: error.message,
+          type: 'error',
+        })
+      }
+    >
+      {children}
+    </ErrorBoundaryInner>
+  );
+}

--- a/src/user/providers/QueryProvider.tsx
+++ b/src/user/providers/QueryProvider.tsx
@@ -1,0 +1,25 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactNode, useMemo } from 'react';
+
+const createClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 30_000,
+        retry: (failureCount, error) => {
+          const status = (error as { response?: { status?: number } })?.response?.status;
+          if (status && status >= 400 && status < 500) return false;
+          return failureCount < 1;
+        },
+        refetchOnWindowFocus: true,
+      },
+      mutations: {
+        retry: 0,
+      },
+    },
+  });
+
+export function QueryProvider({ children }: { children: ReactNode }) {
+  const client = useMemo(createClient, []);
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}

--- a/src/user/providers/ThemeProvider.tsx
+++ b/src/user/providers/ThemeProvider.tsx
@@ -1,0 +1,13 @@
+import { PropsWithChildren, useEffect } from 'react';
+import { useUIStore } from '../state/useUIStore';
+
+export function ThemeProvider({ children }: PropsWithChildren) {
+  const theme = useUIStore(state => state.theme);
+  const applyTheme = useUIStore(state => state.applyTheme);
+
+  useEffect(() => {
+    applyTheme(theme);
+  }, [applyTheme, theme]);
+
+  return children;
+}

--- a/src/user/providers/ToastProvider.tsx
+++ b/src/user/providers/ToastProvider.tsx
@@ -1,0 +1,77 @@
+import { createContext, PropsWithChildren, useCallback, useContext, useMemo, useState } from 'react';
+import { nanoid } from 'nanoid';
+import { cn } from '../utils/cn';
+
+type ToastType = 'info' | 'success' | 'error';
+
+type Toast = {
+  id: string;
+  title: string;
+  description?: string;
+  type: ToastType;
+};
+
+type ToastContextValue = {
+  toasts: Toast[];
+  push: (toast: Omit<Toast, 'id'>) => void;
+  dismiss: (id: string) => void;
+};
+
+const ToastContext = createContext<ToastContextValue | undefined>(undefined);
+
+export function ToastProvider({ children }: PropsWithChildren) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const push = useCallback((toast: Omit<Toast, 'id'>) => {
+    setToasts(prev => [...prev, { ...toast, id: nanoid() }]);
+  }, []);
+
+  const dismiss = useCallback((id: string) => {
+    setToasts(prev => prev.filter(item => item.id !== id));
+  }, []);
+
+  const value = useMemo(() => ({ toasts, push, dismiss }), [toasts, push, dismiss]);
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <div className="fixed inset-x-0 bottom-4 z-[100] flex flex-col items-center gap-2 px-4">
+        {toasts.map(toast => (
+          <div
+            key={toast.id}
+            className={cn(
+              'w-full max-w-sm rounded-lg border bg-background/95 p-4 shadow-lg backdrop-blur',
+              toast.type === 'success' && 'border-emerald-500/60',
+              toast.type === 'error' && 'border-destructive/50',
+              toast.type === 'info' && 'border-primary/40',
+            )}
+            role="status"
+            aria-live="polite"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <p className="text-sm font-semibold">{toast.title}</p>
+                {toast.description ? <p className="text-xs text-muted-foreground">{toast.description}</p> : null}
+              </div>
+              <button
+                type="button"
+                className="rounded-full p-1 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
+                onClick={() => dismiss(toast.id)}
+              >
+                ×
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error('useToast must be used within ToastProvider');
+  }
+  return context;
+}

--- a/src/user/routes.tsx
+++ b/src/user/routes.tsx
@@ -1,0 +1,61 @@
+import { lazy } from 'react';
+import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import { RequireAuth } from './auth/RequireAuth';
+
+const LoginPage = lazy(() => import('./pages/Login/LoginPage'));
+const ChatPage = lazy(() => import('./pages/Chat/ChatPage'));
+const ThreadsPage = lazy(() => import('./pages/Threads/ThreadsPage'));
+const FamilyHubPage = lazy(() => import('./pages/FamilyHub/FamilyHubPage'));
+const KidsPage = lazy(() => import('./pages/Kids/KidsPage'));
+const ProfilePage = lazy(() => import('./pages/Profile/ProfilePage'));
+const SettingsPage = lazy(() => import('./pages/Settings/SettingsPage'));
+const UsagePage = lazy(() => import('./pages/Usage/UsagePage'));
+
+const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <RequireAuth />, // gate protected area
+    children: [
+      {
+        index: true,
+        element: <ChatPage />,
+      },
+      {
+        path: 'chat',
+        element: <ChatPage />,
+      },
+      {
+        path: 'threads/:threadId?',
+        element: <ThreadsPage />,
+      },
+      {
+        path: 'family',
+        element: <FamilyHubPage />,
+      },
+      {
+        path: 'kids',
+        element: <KidsPage />,
+      },
+      {
+        path: 'profile',
+        element: <ProfilePage />,
+      },
+      {
+        path: 'settings',
+        element: <SettingsPage />,
+      },
+      {
+        path: 'usage',
+        element: <UsagePage />,
+      },
+    ],
+  },
+  {
+    path: '/login',
+    element: <LoginPage />,
+  },
+]);
+
+export function UserRoutes() {
+  return <RouterProvider router={router} />;
+}

--- a/src/user/state/useChatStore.ts
+++ b/src/user/state/useChatStore.ts
@@ -1,0 +1,35 @@
+import { create } from 'zustand';
+
+type Drafts = Record<string, string>;
+
+type ChatState = {
+  currentThreadId?: string;
+  draftText: Drafts;
+  streamingThreadId?: string;
+  setCurrentThread: (id?: string) => void;
+  setDraftText: (threadId: string, text: string) => void;
+  clearDraft: (threadId: string) => void;
+  setStreamingThread: (threadId?: string) => void;
+};
+
+export const useChatStore = create<ChatState>(set => ({
+  currentThreadId: undefined,
+  draftText: {},
+  streamingThreadId: undefined,
+  setCurrentThread: id => set(state => ({ ...state, currentThreadId: id })),
+  setDraftText: (threadId, text) =>
+    set(state => ({
+      ...state,
+      draftText: {
+        ...state.draftText,
+        [threadId]: text,
+      },
+    })),
+  clearDraft: threadId =>
+    set(state => {
+      const next = { ...state.draftText };
+      delete next[threadId];
+      return { ...state, draftText: next };
+    }),
+  setStreamingThread: threadId => set(state => ({ ...state, streamingThreadId: threadId })),
+}));

--- a/src/user/state/useFamilyStore.ts
+++ b/src/user/state/useFamilyStore.ts
@@ -1,0 +1,33 @@
+import { create } from 'zustand';
+import type { FamilyOverview, FamilyRequest } from '../api/types';
+
+type FamilyState = {
+  household?: FamilyOverview;
+  pendingRequests: FamilyRequest[];
+  setHousehold: (household?: FamilyOverview) => void;
+  setPendingRequests: (requests: FamilyRequest[]) => void;
+  upsertRequest: (request: FamilyRequest) => void;
+  removeRequest: (id: string) => void;
+};
+
+export const useFamilyStore = create<FamilyState>(set => ({
+  household: undefined,
+  pendingRequests: [],
+  setHousehold: household => set(state => ({ ...state, household })),
+  setPendingRequests: pendingRequests => set(state => ({ ...state, pendingRequests })),
+  upsertRequest: request =>
+    set(state => {
+      const existingIndex = state.pendingRequests.findIndex(item => item.id === request.id);
+      if (existingIndex >= 0) {
+        const next = [...state.pendingRequests];
+        next[existingIndex] = request;
+        return { ...state, pendingRequests: next };
+      }
+      return { ...state, pendingRequests: [...state.pendingRequests, request] };
+    }),
+  removeRequest: id =>
+    set(state => ({
+      ...state,
+      pendingRequests: state.pendingRequests.filter(item => item.id !== id),
+    })),
+}));

--- a/src/user/state/useKidsStore.ts
+++ b/src/user/state/useKidsStore.ts
@@ -1,0 +1,20 @@
+import { create } from 'zustand';
+import type { KidsPreset } from '../api/types';
+
+type KidsState = {
+  presets: KidsPreset[];
+  lastUsed?: string;
+  voiceEnabled: boolean;
+  setPresets: (presets: KidsPreset[]) => void;
+  markUsed: (key: string) => void;
+  setVoiceEnabled: (enabled: boolean) => void;
+};
+
+export const useKidsStore = create<KidsState>(set => ({
+  presets: [],
+  lastUsed: undefined,
+  voiceEnabled: false,
+  setPresets: presets => set(state => ({ ...state, presets })),
+  markUsed: key => set(state => ({ ...state, lastUsed: key })),
+  setVoiceEnabled: enabled => set(state => ({ ...state, voiceEnabled: enabled })),
+}));

--- a/src/user/state/useUIStore.ts
+++ b/src/user/state/useUIStore.ts
@@ -1,0 +1,46 @@
+import { create } from 'zustand';
+
+type Theme = 'light' | 'dark' | 'system';
+
+type UIPanelState = {
+  theme: Theme;
+  compactMode: boolean;
+  language: string;
+  panelSizes: Record<string, number>;
+  setTheme: (theme: Theme) => void;
+  setCompactMode: (value: boolean) => void;
+  setLanguage: (value: string) => void;
+  setPanelSize: (panel: string, size: number) => void;
+  applyTheme: (theme: Theme) => void;
+};
+
+function updateDocumentTheme(theme: Theme) {
+  if (typeof window === 'undefined') return;
+  const root = document.documentElement;
+  const resolved = theme === 'system' ? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light') : theme;
+  root.classList.remove('light', 'dark');
+  root.classList.add(resolved);
+}
+
+export const useUIStore = create<UIPanelState>(set => ({
+  theme: 'system',
+  compactMode: false,
+  language: 'en',
+  panelSizes: {},
+  setTheme: theme => set(state => ({ ...state, theme })),
+  setCompactMode: value => set(state => ({ ...state, compactMode: value })),
+  setLanguage: value => set(state => ({ ...state, language: value })),
+  setPanelSize: (panel, size) =>
+    set(state => ({
+      ...state,
+      panelSizes: {
+        ...state.panelSizes,
+        [panel]: size,
+      },
+    })),
+  applyTheme: theme => updateDocumentTheme(theme),
+}));
+
+useUIStore.subscribe(state => {
+  updateDocumentTheme(state.theme);
+});

--- a/src/user/styles/global.css
+++ b/src/user/styles/global.css
@@ -1,0 +1,18 @@
+@import '../../styles/tokens.css';
+@import '../../styles/theme.css';
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light dark;
+}
+
+body {
+  @apply bg-background text-foreground antialiased;
+}
+
+#root {
+  min-height: 100vh;
+}

--- a/src/user/utils/cn.ts
+++ b/src/user/utils/cn.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: Array<string | false | null | undefined>) {
+  return classes.filter(Boolean).join(' ');
+}


### PR DESCRIPTION
## Summary
- add dedicated user app entrypoint with global providers, auth bootstrap, and routing
- scaffold chat, family hub, kids mode, profile, settings, usage, and login screens with supporting components
- implement axios API adapters and zustand stores for chat, family, kids, and UI state management

## Testing
- npm run typecheck *(fails: existing project type definitions missing react/jsx-runtime and package typings)*

------
https://chatgpt.com/codex/tasks/task_e_68df195a45bc83259a6104dbfcd263e2